### PR TITLE
update svg for rust

### DIFF
--- a/src/assets/svg/rust.svg
+++ b/src/assets/svg/rust.svg
@@ -1,14 +1,58 @@
-<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M64 100.38C28.654 100.38 0 81.19 0 57.5171C0 33.8451 28.654 14.6541 64 14.6541C99.346 14.6541 128 33.8441 128 57.5171C128 81.1891 99.346 100.38 64 100.38ZM73.796 31.4131C46.93 31.4131 25.15 44.5321 25.15 60.7161C25.15 76.8991 46.93 90.0191 73.796 90.0191C100.662 90.0191 120.489 81.0491 120.489 60.7161C120.489 40.3891 100.662 31.4131 73.796 31.4131Z" fill="url(#paint0_linear_3_7110)"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M97.4688 81.033C97.4688 81.033 101.343 82.202 103.593 83.341C104.373 83.736 105.725 84.524 106.699 85.56C107.271 86.1657 107.749 86.8533 108.119 87.6L123.385 113.34L98.7108 113.35L87.1738 91.684C87.1738 91.684 84.8108 87.624 83.3568 86.447C82.1438 85.465 81.6268 85.116 80.4278 85.116H74.5658L74.5698 113.335L52.7368 113.344V41.26H96.5808C96.5808 41.26 116.551 41.62 116.551 60.619C116.551 79.618 97.4688 81.032 97.4688 81.032V81.033ZM87.9718 56.896L74.7538 56.887L74.7478 69.145L87.9718 69.14C87.9718 69.14 94.0958 69.121 94.0958 62.905C94.0958 56.565 87.9718 56.896 87.9718 56.896Z" fill="url(#paint1_linear_3_7110)"/>
-<defs>
-<linearGradient id="paint0_linear_3_7110" x1="0.000721986" y1="14.6446" x2="79.2728" y2="133.005" gradientUnits="userSpaceOnUse">
-<stop stop-color="#CBCED0"/>
-<stop offset="1" stop-color="#84838B"/>
-</linearGradient>
-<linearGradient id="paint1_linear_3_7110" x1="52.7368" y1="41.2595" x2="124.812" y2="111.892" gradientUnits="userSpaceOnUse">
-<stop stop-color="#276DC3"/>
-<stop offset="1" stop-color="#165CAA"/>
-</linearGradient>
-</defs>
-</svg>
+
+    <svg version="1.1" height="106" width="106" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="logo" transform="translate(53, 53)">
+    <path id="r" transform="translate(0.5, 0.5)" stroke="black" stroke-width="1" stroke-linejoin="round" d=" M -9,-15 H 4 C 12,-15 12,-7 4,-7 H -9 Z M -40,22 H 0 V 11 H -9 V 3 H 1 C 12,3 6,22 15,22 H 40 V 3 H 34 V 5 C 34,13 25,12 24,7 C 23,2 19,-2 18,-2 C 33,-10 24,-26 12,-26 H -35 V -15 H -25 V 11 H -40 Z"/>
+    <g id="gear" mask="url(#holes)">
+    <circle r="43" fill="none" stroke="black" stroke-width="9"/>
+    <g id="cogs">
+    <polygon id="cog" stroke="black" stroke-width="3" stroke-linejoin="round" points="46,3 51,0 46,-3"/>
+    <use xlink:href="#cog" transform="rotate(11.25)"/>
+    <use xlink:href="#cog" transform="rotate(22.50)"/>
+    <use xlink:href="#cog" transform="rotate(33.75)"/>
+    <use xlink:href="#cog" transform="rotate(45.00)"/>
+    <use xlink:href="#cog" transform="rotate(56.25)"/>
+    <use xlink:href="#cog" transform="rotate(67.50)"/>
+    <use xlink:href="#cog" transform="rotate(78.75)"/>
+    <use xlink:href="#cog" transform="rotate(90.00)"/>
+    <use xlink:href="#cog" transform="rotate(101.25)"/>
+    <use xlink:href="#cog" transform="rotate(112.50)"/>
+    <use xlink:href="#cog" transform="rotate(123.75)"/>
+    <use xlink:href="#cog" transform="rotate(135.00)"/>
+    <use xlink:href="#cog" transform="rotate(146.25)"/>
+    <use xlink:href="#cog" transform="rotate(157.50)"/>
+    <use xlink:href="#cog" transform="rotate(168.75)"/>
+    <use xlink:href="#cog" transform="rotate(180.00)"/>
+    <use xlink:href="#cog" transform="rotate(191.25)"/>
+    <use xlink:href="#cog" transform="rotate(202.50)"/>
+    <use xlink:href="#cog" transform="rotate(213.75)"/>
+    <use xlink:href="#cog" transform="rotate(225.00)"/>
+    <use xlink:href="#cog" transform="rotate(236.25)"/>
+    <use xlink:href="#cog" transform="rotate(247.50)"/>
+    <use xlink:href="#cog" transform="rotate(258.75)"/>
+    <use xlink:href="#cog" transform="rotate(270.00)"/>
+    <use xlink:href="#cog" transform="rotate(281.25)"/>
+    <use xlink:href="#cog" transform="rotate(292.50)"/>
+    <use xlink:href="#cog" transform="rotate(303.75)"/>
+    <use xlink:href="#cog" transform="rotate(315.00)"/>
+    <use xlink:href="#cog" transform="rotate(326.25)"/>
+    <use xlink:href="#cog" transform="rotate(337.50)"/>
+    <use xlink:href="#cog" transform="rotate(348.75)"/>
+    </g>
+    <g id="mounts">
+    <polygon id="mount" stroke="black" stroke-width="6" stroke-linejoin="round" points="-7,-42 0,-35 7,-42"/>
+    <use xlink:href="#mount" transform="rotate(72)"/>
+    <use xlink:href="#mount" transform="rotate(144)"/>
+    <use xlink:href="#mount" transform="rotate(216)"/>
+    <use xlink:href="#mount" transform="rotate(288)"/>
+    </g>
+    </g>
+    <mask id="holes">
+    <rect x="-60" y="-60" width="120" height="120" fill="white"/>
+    <circle id="hole" cy="-40" r="3"/>
+    <use xlink:href="#hole" transform="rotate(72)"/>
+    <use xlink:href="#hole" transform="rotate(144)"/>
+    <use xlink:href="#hole" transform="rotate(216)"/>
+    <use xlink:href="#hole" transform="rotate(288)"/>
+    </mask>
+    </g>
+    </svg>


### PR DESCRIPTION
This PR updates the [RUST](https://www.rust-lang.org/) SVG. Former SVG used was for the [R](https://www.r-project.org/) programming language