### PR TITLE
feat: add LinkedIn and Instagram social profiles

### DIFF
--- a/src/pages/dashboard/editor/components/AIChat.jsx
+++ b/src/pages/dashboard/editor/components/AIChat.jsx
@@ -45,6 +45,18 @@ const AIChat = ({ formData, setFormData, selectedTech, handleTechSelect, handleT
             setFormData(prev => ({ ...prev, github }));
             response = `Updated GitHub handle.`;
         }
+        // LinkedIn
+        else if (lowerText.includes("linkedin")) {
+            const linkedin = text.split(" ").pop();
+            setFormData(prev => ({ ...prev, linkedin }));
+            response = `Updated LinkedIn handle.`;
+        }
+        // Instagram
+        else if (lowerText.includes("instagram")) {
+            const instagram = text.split(" ").pop();
+            setFormData(prev => ({ ...prev, instagram }));
+            response = `Updated Instagram handle.`;
+        }
         // Add Tech
         else if (lowerText.includes("add")) {
             const techQuery = text.replace("add", "").trim().toLowerCase();

--- a/src/pages/dashboard/editor/components/BannerCard.jsx
+++ b/src/pages/dashboard/editor/components/BannerCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Twitter, Github, MapPin, Link as LinkIcon } from 'lucide-react';
+import { Twitter, Github, Linkedin, Instagram, MapPin, Link as LinkIcon } from 'lucide-react';
 import { PATTERN_STYLES } from '../constants';
 
 const BannerCard = ({ formData, setFormData, selectedTech, availableLanguages }) => {
@@ -76,6 +76,20 @@ const BannerCard = ({ formData, setFormData, selectedTech, availableLanguages })
                                     <span className="font-medium">{formData.github}</span>
                                 </div>
                             )}
+
+                            {formData.linkedin && (
+                                <div className="flex items-center gap-2 text-white/90 drop-shadow-md">
+                                    <Linkedin size={20} fill="currentColor" className="text-blue-300" />
+                                    <span className="font-medium">{formData.linkedin}</span>
+                                </div>
+                            )}
+
+                            {formData.instagram && (
+                                <div className="flex items-center gap-2 text-white/90 drop-shadow-md">
+                                    <Instagram size={20} className="text-pink-400" />
+                                    <span className="font-medium">@{formData.instagram.replace('@', '')}</span>
+                                </div>
+                            )}
                         </div>
                     )}
                 </div>
@@ -139,6 +153,20 @@ const BannerCard = ({ formData, setFormData, selectedTech, availableLanguages })
                             <div className="flex items-center gap-2 text-white/90 drop-shadow-md">
                                 <Github size={20} fill="currentColor" />
                                 <span className="font-medium">{formData.github}</span>
+                            </div>
+                        )}
+
+                        {formData.linkedin && (
+                            <div className="flex items-center gap-2 text-white/90 drop-shadow-md">
+                                <Linkedin size={20} fill="currentColor" className="text-blue-300" />
+                                <span className="font-medium">{formData.linkedin}</span>
+                            </div>
+                        )}
+
+                        {formData.instagram && (
+                            <div className="flex items-center gap-2 text-white/90 drop-shadow-md">
+                                <Instagram size={20} className="text-pink-400" />
+                                <span className="font-medium">@{formData.instagram.replace('@', '')}</span>
                             </div>
                         )}
                     </div>

--- a/src/pages/dashboard/editor/components/ProfileEditor.jsx
+++ b/src/pages/dashboard/editor/components/ProfileEditor.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { User, Briefcase, Twitter, Github, Lock, Eye, EyeOff } from 'lucide-react';
+import { User, Briefcase, Twitter, Github, Linkedin, Instagram, Lock, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '../../../../context/AuthContext';
 import UpgradeModal from './UpgradeModal';
 
@@ -107,6 +107,41 @@ const ProfileEditor = ({ formData, handleFormChange }) => {
                             onChange={handleFormChange}
                             placeholder="username"
                             className="w-full px-4 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:bg-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all"
+                        />
+                    </div>
+                </div>
+
+                <div className="group">
+                    <label className="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase tracking-wider mb-1.5">
+                        <Linkedin size={12} className="text-blue-700" />
+                        LinkedIn
+                    </label>
+                    <div className="relative">
+                        <input
+                            type="text"
+                            name="linkedin"
+                            value={formData.linkedin}
+                            onChange={handleFormChange}
+                            placeholder="username or profile URL"
+                            className="w-full px-4 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:bg-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all"
+                        />
+                    </div>
+                </div>
+
+                <div className="group">
+                    <label className="flex items-center gap-2 text-xs font-bold text-gray-500 uppercase tracking-wider mb-1.5">
+                        <Instagram size={12} className="text-pink-500" />
+                        Instagram
+                    </label>
+                    <div className="relative">
+                        <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 text-sm">@</span>
+                        <input
+                            type="text"
+                            name="instagram"
+                            value={formData.instagram.replace(/^@/, '')}
+                            onChange={(e) => handleFormChange({ target: { name: 'instagram', value: e.target.value ? `@${e.target.value.replace(/^@/, '')}` : '' } })}
+                            placeholder="username"
+                            className="w-full pl-8 pr-4 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:bg-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all"
                         />
                     </div>
                 </div>

--- a/src/pages/dashboard/editor/page.jsx
+++ b/src/pages/dashboard/editor/page.jsx
@@ -16,6 +16,8 @@ const initialFormState = {
     field: "",
     twitter: "",
     github: "",
+    linkedin: "",
+    instagram: "",
     rgbabackground: "linear-gradient(to right, #4f46e5, #9333ea)",
     layout: "standard",
     techStackStyle: "glass",


### PR DESCRIPTION
- Add linkedin and instagram fields to initialFormState (page.jsx)

- Add LinkedIn input field with Linkedin icon and Instagram input with @ prefix in ProfileEditor sidebar

- Render LinkedIn and Instagram icons/handles on banner in both modern and standard layouts (BannerCard.jsx)

- Add AI chat command handlers for linkedin and instagram (AIChat.jsx)